### PR TITLE
Single refreshdatabase trait

### DIFF
--- a/tests/Feature/CreateMeetingsTest.php
+++ b/tests/Feature/CreateMeetingsTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Meeting;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class CreateMeetingsTest extends TestCase
 {

--- a/tests/Feature/CreateMeetingsTest.php
+++ b/tests/Feature/CreateMeetingsTest.php
@@ -8,7 +8,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class CreateMeetingsTest extends TestCase
 {
-    use RefreshDatabase;
 
     /** @test */
     public function the_route_to_create_meetings_is_not_visible_to_guests()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,12 +4,14 @@ namespace Tests;
 
 use App\User;
 use App\Services\RoleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\CreateMeetingsTest;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    use RefreshDatabase;
 
     protected function signIn($role = 'user')
     {

--- a/tests/Unit/MeetingServiceTest.php
+++ b/tests/Unit/MeetingServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Unit;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Meeting;
@@ -13,7 +12,6 @@ use App\Traits\HasUserTests;
 class MeetingServiceTest extends TestCase
 {
     use HasUserTests;
-    use RefreshDatabase;
 
     /**
      * A basic feature test example.

--- a/tests/Unit/MeetingUserServiceTest.php
+++ b/tests/Unit/MeetingUserServiceTest.php
@@ -8,7 +8,6 @@ use App\Traits\HasUserTests;
 use App\Traits\HasMeetingTests;
 use App\User;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 

--- a/tests/Unit/MeetingUserServiceTest.php
+++ b/tests/Unit/MeetingUserServiceTest.php
@@ -14,7 +14,6 @@ use Tests\TestCase;
 
 class MeetingUserServiceTest extends TestCase
 {
-    use RefreshDatabase;
     use HasUserTests;
     use HasMeetingTests;
 


### PR DESCRIPTION
Moving the RefreshDatabase trait to the parent would prevent us from needing to remember to include this trait in every test. Is there ever a time we _wouldn't_ want to use it?